### PR TITLE
Introduction of $ASSET_BASE_FOLDER - allowing for base folder poster downloading.

### DIFF
--- a/default.env
+++ b/default.env
@@ -17,7 +17,7 @@ METADATA_MOVIES=/path/to/PMM/config/movies-mal.yml
 # (PMM) Asset Folder to import posters (Needed)
 ASSET_FOLDER=/path/to/PMM/config/assets
 # Keep assets in the base folder (Yes) or in subsequent (per anime) asset_folder. (No) 
-ASSET_BASE_FOLDER=Yes
+ASSET_BASE_FOLDER=No
 
 # Folder where the logs of script are kept (Default is okay change if you want)
 LOG_FOLDER=$SCRIPT_FOLDER/logs

--- a/default.env
+++ b/default.env
@@ -14,8 +14,11 @@ MOVIE_LIBRARY_NAME="Animes Movies"
 METADATA_ANIMES=/path/to/PMM/config/animes-mal.yml
 # Path to the created movies metadata file (Needed for the movies script)
 METADATA_MOVIES=/path/to/PMM/config/movies-mal.yml
-# PMM Asset Folder to import posters (Needed)
+# (PMM) Asset Folder to import posters (Needed)
 ASSET_FOLDER=/path/to/PMM/config/assets
+# Keep assets in the base folder (Yes) or in subsequent (per anime) asset_folder. (No) 
+ASSET_BASE_FOLDER=Yes
+
 # Folder where the logs of script are kept (Default is okay change if you want)
 LOG_FOLDER=$SCRIPT_FOLDER/logs
 

--- a/functions.sh
+++ b/functions.sh
@@ -209,7 +209,7 @@ function get-poster () {
 	then
 		if [ ! -f "$ASSET_FOLDER/$asset_name/poster.jpg" ]
 		then
-			if [ ! -d "$ASSET_FOLDER/$asset_name" ]
+			if [[ $ASSET_BASE_FOLDER == "No" && ! -d "$ASSET_FOLDER/$asset_name" ]]
 			then
 				mkdir "$ASSET_FOLDER/$asset_name"
 			fi
@@ -258,7 +258,7 @@ function get-poster () {
 		fi
 		if [[ $ASSET_BASE_FOLDER == "Yes" ]]
 		then
-			cleaned_asset_name=$(echo "$asset_name" | awk '{sub(/ *\{imdb-[^}]*\} */, ""); print}')
+			cleaned_asset_name=$(echo "$asset_name" | awk '{sub(/ *(\{|\[)imdb-[^}\]]*(\}|\]) */, ""); print}')
 			mv "$ASSET_FOLDER/$asset_name/poster.jpg" "$ASSET_FOLDER/$cleaned_asset_name.jpg"
 		fi
 	fi
@@ -324,7 +324,7 @@ function get-season-poster () {
 		if [[ $ASSET_BASE_FOLDER == "Yes" ]]
 		then
 			# Removing the {imdb-} part from asset_name
-			cleaned_asset_name=$(echo "$asset_name" | awk '{sub(/ *\{imdb-[^}]*\} */, ""); print}')
+			cleaned_asset_name=$(echo "$asset_name" | awk '{sub(/ *(\{|\[)imdb-[^}\]]*(\}|\]) */, ""); print}')
 
 			# Determining the season name based on season number
 			if [[ $season_number -eq 0 ]]

--- a/functions.sh
+++ b/functions.sh
@@ -254,6 +254,11 @@ function get-poster () {
 				fi
 			fi
 		fi
+		if [[ $ASSET_BASE_FOLDER == "Yes" ]]
+		then
+			cleaned_asset_name=$(echo "$asset_name" | awk '{sub(/ *\{imdb-[^}]*\} */, ""); print}')
+			mv "$ASSET_FOLDER/$asset_name/poster.jpg" "$ASSET_FOLDER/$cleaned_asset_name.jpg"
+		fi
 	fi
 }
 function get-season-poster () {
@@ -313,6 +318,25 @@ function get-season-poster () {
 					printf "%s\t\t - Done\n" "$(date +%H:%M:%S)" | tee -a "$LOG"
 				fi
 			fi
+		fi
+		if [[ $ASSET_BASE_FOLDER == "Yes" ]]
+		then
+			# Removing the {imdb-} part from asset_name
+			cleaned_asset_name=$(echo "$asset_name" | awk '{sub(/ *\{imdb-[^}]*\} */, ""); print}')
+
+			# Determining the season name based on season number
+			if [[ $season_number -eq 0 ]]
+			then
+				season_name="specials"
+			elif [[ $season_number -lt 10 ]]
+			then
+				season_name="season 0$season_number"
+			else
+				season_name="season $season_number"
+			fi
+
+			# Rename the file to the cleaned name
+			mv "$assets_filepath" "$ASSET_FOLDER/$cleaned_asset_name - $season_name.jpg"
 		fi
 	fi
 }

--- a/functions.sh
+++ b/functions.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 #General variables
+export LC_ALL=en_US.UTF-8
+locale -a
 LOG=$LOG_FOLDER/${media_type}_$(date +%Y.%m.%d).log
 MATCH_LOG=$LOG_FOLDER/${media_type}-missing-id.log
 

--- a/functions.sh
+++ b/functions.sh
@@ -209,7 +209,7 @@ function get-poster () {
 	then
 		if [ ! -f "$ASSET_FOLDER/$asset_name/poster.jpg" ]
 		then
-			if [[ $ASSET_BASE_FOLDER == "No" && ! -d "$ASSET_FOLDER/$asset_name" ]]
+			if [ ! -d "$ASSET_FOLDER/$asset_name" ]
 			then
 				mkdir "$ASSET_FOLDER/$asset_name"
 			fi
@@ -260,6 +260,7 @@ function get-poster () {
 		then
 			cleaned_asset_name=$(echo "$asset_name" | awk '{sub(/ *(\{|\[)imdb-[^}\]]*(\}|\]) */, ""); print}')
 			mv "$ASSET_FOLDER/$asset_name/poster.jpg" "$ASSET_FOLDER/$cleaned_asset_name.jpg"
+   			rmdir "$ASSET_FOLDER/$asset_name"
 		fi
 	fi
 }
@@ -339,6 +340,7 @@ function get-season-poster () {
 
 			# Rename the file to the cleaned name
 			mv "$assets_filepath" "$ASSET_FOLDER/$cleaned_asset_name - $season_name.jpg"
+   			rmdir "$ASSET_FOLDER/$asset_name"
 		fi
 	fi
 }


### PR DESCRIPTION
Introduction of $ASSET_BASE_FOLDER, defaults to No
Changes to get-poster and get-season-poster.
Introduction of UTF8 and locale.

This change will only come in effect when variable `ASSET_BASE_FOLDER=Yes`
This will save the posters / season posters in the $ASSET_FOLDER, instead of $ASSET_FOLDER/$asset_name/

At the same time, the posters cannot be the same name so, for normal posters:
poster.jpg  >> make use of $asset_name >> {Anime name} {year}.jpg. I also made sure to strip {imdb-}, as this causes issues.

Season posters:
Season0$season_number.jpg >> making use of $asset_name again >> {Anime Name} {year} - {Season$season_number}.jpg

With that the end result will look like this, taking death note as an example:

Poster: Death Note (2006).jpg
Season: Death Note (2006) - Season 1.jpg